### PR TITLE
fix(cluster-policy): fix storage bucket descriptor, remove unsupported twine skip-existing flag, and update docs

### DIFF
--- a/composer_cluster_policy/README.md
+++ b/composer_cluster_policy/README.md
@@ -214,7 +214,8 @@ python3 -m twine upload \
 ```bash
 BUCKET=$(gcloud composer environments describe composer-3-airflow-3 \
     --location=us-central1 \
-    --format="value(config.storageConfig.bucket)")
+    --format="value(storageConfig.bucket)")
+BUCKET="${BUCKET#gs://}"
 
 cat << EOF > pip.conf
 [global]
@@ -246,9 +247,34 @@ python3 -m unittest discover -s tests
 # Ran 17 tests in 0.002s - OK
 ```
 
----
-
 ### 2. Live Cluster Verification Across the 3 Tiers
+
+#### Step 1: Clone Repository & Deploy Demonstration DAGs
+
+##### If cloning for the first time:
+```bash
+git clone https://github.com/GoogleCloudPlatform/composer-utilities.git
+cd composer-utilities/composer_cluster_policy
+```
+
+##### If repository is already cloned:
+```bash
+cd composer-utilities/composer_cluster_policy
+# Or if already in the repo root:
+# cd composer_cluster_policy
+```
+
+##### Sync Demonstration DAGs to Cloud Storage:
+```bash
+BUCKET="$(gcloud composer environments describe large-central1-airflow3 \
+    --location=us-central1 \
+    --format="value(storageConfig.bucket)")"
+BUCKET="${BUCKET#gs://}"
+
+gcloud storage cp dags/*.py "gs://${BUCKET}/dags/"
+```
+
+---
 
 #### Tier 1: DAG-Level Governance (`dag_policy`)
 * **Before (`sample_dag_policy_violations_dag.py`)**:

--- a/composer_cluster_policy/deploy_policy.sh
+++ b/composer_cluster_policy/deploy_policy.sh
@@ -83,7 +83,8 @@ gcloud artifacts repositories add-iam-policy-binding "${AR_REPO}" \
 # 5. Build Distribution Wheel
 echo "[+] Building cluster policy distribution wheel..."
 cd "${PACKAGE_DIR}"
-rm -rf dist/ build/ *.egg-info
+rm -rf dist/ build/
+rm -rf *.egg-info src/*.egg-info 2>/dev/null || true
 pip3 wheel --no-deps -w dist/ .
 
 WHEEL_FILE="$(ls dist/*.whl | head -n 1)"
@@ -96,12 +97,13 @@ python3 -m twine upload \
     --username oauth2accesstoken \
     --password "$(gcloud auth print-access-token)" \
     --repository-url "https://${LOCATION}-python.pkg.dev/${PROJECT_ID}/${AR_REPO}/" \
-    "${WHEEL_FILE}" --skip-existing
+    "${WHEEL_FILE}"
 
 # 7. Configure Environment pip.conf
 BUCKET="$(gcloud composer environments describe "${ENV_NAME}" \
     --location="${LOCATION}" \
-    --format="value(config.storageConfig.bucket)")"
+    --format="value(storageConfig.bucket)")"
+BUCKET="${BUCKET#gs://}"
 
 echo "[+] Generating and uploading pip.conf to gs://${BUCKET}/config/pip/pip.conf..."
 cat << EOF > "${PACKAGE_DIR}/pip.conf"

--- a/composer_cluster_policy/pyproject.toml
+++ b/composer_cluster_policy/pyproject.toml
@@ -25,7 +25,7 @@ requires-python = ">=3.9"
 dependencies = []
 
 [project.entry-points."airflow.policy"]
-_ = "composer_cluster_policy.policies"
+composer_cluster_policy = "composer_cluster_policy.policies"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
## Summary
Follow-up fixes for #115:
- **Bucket Descriptor Fix**: Updated `storageConfig.bucket` in `deploy_policy.sh` and `README.md` (with `${BUCKET#gs://}` handling to prevent empty or malformed paths).
- **Twine Upload Fix**: Removed unsupported `--skip-existing` flag from `twine upload` which causes `UnsupportedConfiguration` errors against Google Artifact Registry.
- **Entrypoint Name**: Explicitly named the `[airflow.policy]` entry point in `pyproject.toml` as `composer_cluster_policy = "composer_cluster_policy.policies"`.
- **Documentation**: Updated hands-on verification instructions in `README.md` to cover both first-time cloning and existing repository workflows.

## Test Plan
- Ran unit test suite locally: `python3 -m unittest discover -s composer_cluster_policy/tests` (17/17 tests passing).
- Verified on live Cloud Composer 3 environment (`composer-3-airflow-3.3.1-build.0`).