### PR TITLE
docs(cluster-policy): update module and test docstrings to reflect Artifact Registry deployment

### DIFF
--- a/composer_cluster_policy/airflow_local_settings.py
+++ b/composer_cluster_policy/airflow_local_settings.py
@@ -35,8 +35,9 @@ and operational resilience policies for Google Cloud Composer (Composer 2 and Co
    - Enforces DAG ownership, tags, and documentation standards.
 
 Deployment:
-Place this file as `airflow_local_settings.py` in your Cloud Composer environment's
-`plugins/` folder (or sync via GCS: `gs://<composer-bucket>/plugins/airflow_local_settings.py`).
+Packaged as a Python distribution wheel and installed into Cloud Composer via
+Google Cloud Artifact Registry registering the `[airflow.policy]` entry point.
+See `deploy_policy.sh` and `README.md` for full deployment instructions.
 """
 
 from __future__ import annotations

--- a/composer_cluster_policy/src/composer_cluster_policy/policies.py
+++ b/composer_cluster_policy/src/composer_cluster_policy/policies.py
@@ -35,8 +35,9 @@ and operational resilience policies for Google Cloud Composer (Composer 2 and Co
    - Enforces DAG ownership, tags, and documentation standards.
 
 Deployment:
-Place this file as `airflow_local_settings.py` in your Cloud Composer environment's
-`plugins/` folder (or sync via GCS: `gs://<composer-bucket>/plugins/airflow_local_settings.py`).
+Packaged as a Python distribution wheel and installed into Cloud Composer via
+Google Cloud Artifact Registry registering the `[airflow.policy]` entry point.
+See `deploy_policy.sh` and `README.md` for full deployment instructions.
 """
 
 from __future__ import annotations

--- a/composer_cluster_policy/tests/test_cluster_policy.py
+++ b/composer_cluster_policy/tests/test_cluster_policy.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for Composer Cluster Policy (airflow_local_settings)."""
+"""Unit tests for Composer Cluster Policy package (composer_cluster_policy)."""
 
 import os
 import sys
@@ -60,7 +60,7 @@ class TestResourceParsers(unittest.TestCase):
 
 
 class TestPodMutationHook(unittest.TestCase):
-    """Tests for pod_mutation_hook in airflow_local_settings."""
+    """Tests for pod_mutation_hook in composer_cluster_policy."""
 
     def setUp(self):
         self.container = MockObject(
@@ -185,7 +185,7 @@ class TestPodMutationHook(unittest.TestCase):
 
 
 class TestTaskPolicy(unittest.TestCase):
-    """Tests for task_policy in airflow_local_settings."""
+    """Tests for task_policy in composer_cluster_policy."""
 
     def test_enforces_execution_timeout(self):
         task = MockObject(task_id="test_task", execution_timeout=None, retries=1)
@@ -215,7 +215,7 @@ class TestTaskPolicy(unittest.TestCase):
 
 
 class TestDagPolicy(unittest.TestCase):
-    """Tests for dag_policy in airflow_local_settings."""
+    """Tests for dag_policy in composer_cluster_policy."""
 
     def test_dag_policy_runs_cleanly(self):
         dag = MockObject(


### PR DESCRIPTION
## Summary
- Replaced legacy `plugins/airflow_local_settings.py` deployment instructions in `policies.py` and `airflow_local_settings.py` with modern Artifact Registry wheel deployment instructions.
- Updated `tests/test_cluster_policy.py` docstrings to reference the `composer_cluster_policy` package.

## Test Plan
- Ran unit tests: `python3 -m unittest discover -s composer_cluster_policy/tests` (17/17 tests passing).